### PR TITLE
No command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ a collection of random scripts for openstax developers
 to install this repo for the first time run:
 ```
 curl https://raw.githubusercontent.com/openstax/ox-bin/main/remote-install.bash | bash
-
-which will checkout this repo to ~/.ox-bin and add a symlink on your path to the `ox` command
 ```
+which will checkout this repo to ~/.ox-bin and add a symlink on your path to the `ox` command
 
 ## udpate
 to get updates to this repo after installing it run:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ a collection of random scripts for openstax developers
 to install this repo for the first time run:
 ```
 curl https://raw.githubusercontent.com/openstax/ox-bin/main/remote-install.bash | bash
+
+which will checkout this repo to ~/.ox-bin and add a symlink on your path to the `ox` command
 ```
 
 ## udpate

--- a/bin/ox
+++ b/bin/ox
@@ -48,12 +48,9 @@ case "$cmd" in
     git submodule update --init --recursive
     "$install_location"/bin/ox register
     ;;
-  "")
-    usage
-    ;;
   *)
     command_file="$install_location/lib/$cmd"
-    if [ ! -x "$command_file" ]; then
+    if [ ! -f "$command_file" ] || [ ! -x "$command_file" ]; then
       usage
     fi
 

--- a/bin/ox
+++ b/bin/ox
@@ -48,6 +48,9 @@ case "$cmd" in
     git submodule update --init --recursive
     "$install_location"/bin/ox register
     ;;
+  "")
+    usage
+    ;;
   *)
     command_file="$install_location/lib/$cmd"
     if [ ! -x "$command_file" ]; then


### PR DESCRIPTION
Handle the base `ox` case w/ the usage text. Otherwise, the catchall complains about '/home/<yourusername>/.ox-bin/lib is a directory'